### PR TITLE
Split root check

### DIFF
--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/DozePermissionObserver.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/DozePermissionObserver.java
@@ -21,16 +21,15 @@ import android.content.Context;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import com.pyamsoft.powermanager.base.PowerManagerPreferences;
-import com.pyamsoft.powermanager.base.shell.ShellCommandHelper;
+import com.pyamsoft.powermanager.base.shell.RootChecker;
 import javax.inject.Inject;
 import timber.log.Timber;
 
 class DozePermissionObserver extends RootPermissionObserver {
 
   @Inject DozePermissionObserver(@NonNull Context context,
-      @NonNull PowerManagerPreferences preferences,
-      @NonNull ShellCommandHelper shellCommandHelper) {
-    super(context, preferences, shellCommandHelper, Manifest.permission.DUMP);
+      @NonNull PowerManagerPreferences preferences, @NonNull RootChecker rootChecker) {
+    super(context, preferences, rootChecker, Manifest.permission.DUMP);
   }
 
   @Override protected boolean checkPermission(@NonNull Context appContext) {

--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/PermissionObserverModule.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/PermissionObserverModule.java
@@ -19,7 +19,7 @@ package com.pyamsoft.powermanager.base.observer.permission;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import com.pyamsoft.powermanager.base.PowerManagerPreferences;
-import com.pyamsoft.powermanager.base.shell.ShellCommandHelper;
+import com.pyamsoft.powermanager.base.shell.RootChecker;
 import com.pyamsoft.powermanager.model.PermissionObserver;
 import dagger.Module;
 import dagger.Provides;
@@ -29,15 +29,15 @@ import javax.inject.Singleton;
 @Module public class PermissionObserverModule {
 
   @Singleton @Named("obs_root_permission") @Provides
-  PermissionObserver provideRootPermissionObserver(@NonNull ShellCommandHelper shellCommandHelper,
+  PermissionObserver provideRootPermissionObserver(@NonNull RootChecker rootChecker,
       @NonNull Context context, @NonNull PowerManagerPreferences preferences) {
-    return new RootPermissionObserver(context, preferences, shellCommandHelper);
+    return new RootPermissionObserver(context, preferences, rootChecker);
   }
 
   @Singleton @Named("obs_doze_permission") @Provides
-  PermissionObserver provideDozePermissionObserver(@NonNull ShellCommandHelper shellCommandHelper,
+  PermissionObserver provideDozePermissionObserver(@NonNull RootChecker rootChecker,
       @NonNull Context context, @NonNull PowerManagerPreferences preferences) {
-    return new DozePermissionObserver(context, preferences, shellCommandHelper);
+    return new DozePermissionObserver(context, preferences, rootChecker);
   }
 
   @Singleton @Named("obs_write_permission") @Provides

--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/RootPermissionObserver.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/observer/permission/RootPermissionObserver.java
@@ -20,31 +20,30 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.pyamsoft.powermanager.base.PowerManagerPreferences;
-import com.pyamsoft.powermanager.base.shell.ShellCommandHelper;
+import com.pyamsoft.powermanager.base.shell.RootChecker;
 import javax.inject.Inject;
 import timber.log.Timber;
 
 class RootPermissionObserver extends PermissionObserverImpl {
 
   @NonNull private final PowerManagerPreferences preferences;
-  @NonNull private final ShellCommandHelper shellCommandHelper;
+  @NonNull private final RootChecker rootChecker;
 
   @Inject RootPermissionObserver(@NonNull Context context,
-      @NonNull PowerManagerPreferences preferences,
-      @NonNull ShellCommandHelper shellCommandHelper) {
-    this(context, preferences, shellCommandHelper, null);
+      @NonNull PowerManagerPreferences preferences, @NonNull RootChecker rootChecker) {
+    this(context, preferences, rootChecker, null);
   }
 
   RootPermissionObserver(@NonNull Context context, @NonNull PowerManagerPreferences preferences,
-      @NonNull ShellCommandHelper shellCommandHelper, @Nullable String permission) {
+      @NonNull RootChecker rootChecker, @Nullable String permission) {
     super(context, permission);
     this.preferences = preferences;
-    this.shellCommandHelper = shellCommandHelper;
+    this.rootChecker = rootChecker;
   }
 
   @Override protected boolean checkPermission(@NonNull Context appContext) {
     if (preferences.isRootEnabled()) {
-      final boolean hasPermission = shellCommandHelper.isSUAvailable();
+      final boolean hasPermission = rootChecker.isSUAvailable();
       Timber.d("Has root permission? %s", hasPermission);
       return hasPermission;
     } else {

--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/RootChecker.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/RootChecker.java
@@ -16,24 +16,10 @@
 
 package com.pyamsoft.powermanager.base.shell;
 
-import android.support.annotation.NonNull;
-import dagger.Module;
-import dagger.Provides;
-import javax.inject.Singleton;
+import android.support.annotation.CheckResult;
+import android.support.annotation.WorkerThread;
 
-@Module public class ShellCommandModule {
+public interface RootChecker {
 
-  @NonNull private final ShellHandlerImpl impl;
-
-  public ShellCommandModule() {
-    impl = new ShellHandlerImpl();
-  }
-
-  @Singleton @Provides ShellCommandHelper provideShellCommandHelper() {
-    return impl;
-  }
-
-  @Singleton @Provides RootChecker provideRootChecker() {
-    return impl;
-  }
+  @WorkerThread @CheckResult boolean isSUAvailable();
 }

--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/ShellCommandHelper.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/ShellCommandHelper.java
@@ -22,8 +22,6 @@ import android.support.annotation.WorkerThread;
 
 public interface ShellCommandHelper {
 
-  @WorkerThread @CheckResult boolean isSUAvailable();
-
   @WorkerThread void runSUCommand(@NonNull String... commands);
 
   @WorkerThread void runSHCommand(@NonNull String... commands);

--- a/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/ShellHandlerImpl.java
+++ b/powermanager-base/src/main/java/com/pyamsoft/powermanager/base/shell/ShellHandlerImpl.java
@@ -26,14 +26,14 @@ import java.util.List;
 import javax.inject.Inject;
 import timber.log.Timber;
 
-class ShellCommandHelperImpl implements ShellCommandHelper {
+class ShellHandlerImpl implements ShellCommandHelper, RootChecker {
 
   private static final int SHELL_TYPE_ROOT = 0;
   private static final int SHELL_TYPE_NORMAL = 1;
   @NonNull private Shell.Interactive shellSession;
   @NonNull private Shell.Interactive rootSession;
 
-  @Inject ShellCommandHelperImpl() {
+  @Inject ShellHandlerImpl() {
     shellSession = openShellSession(false);
     rootSession = openShellSession(true);
   }

--- a/powermanager-settings/src/main/java/com/pyamsoft/powermanager/settings/SettingsPreferenceInteractor.java
+++ b/powermanager-settings/src/main/java/com/pyamsoft/powermanager/settings/SettingsPreferenceInteractor.java
@@ -20,7 +20,7 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import com.pyamsoft.powermanager.base.PowerManagerPreferences;
 import com.pyamsoft.powermanager.base.db.PowerTriggerDB;
-import com.pyamsoft.powermanager.base.shell.ShellCommandHelper;
+import com.pyamsoft.powermanager.base.shell.RootChecker;
 import com.pyamsoft.powermanager.trigger.TriggerInteractor;
 import javax.inject.Inject;
 import rx.Observable;
@@ -28,17 +28,17 @@ import timber.log.Timber;
 
 class SettingsPreferenceInteractor {
 
-  @SuppressWarnings("WeakerAccess") @NonNull final ShellCommandHelper shellCommandHelper;
+  @SuppressWarnings("WeakerAccess") @NonNull final RootChecker rootChecker;
   @SuppressWarnings("WeakerAccess") @NonNull final PowerManagerPreferences preferences;
   @SuppressWarnings("WeakerAccess") @NonNull final PowerTriggerDB powerTriggerDB;
-  @NonNull final TriggerInteractor triggerInteractor;
+  @SuppressWarnings("WeakerAccess") @NonNull final TriggerInteractor triggerInteractor;
 
   @Inject SettingsPreferenceInteractor(@NonNull PowerTriggerDB powerTriggerDB,
-      @NonNull PowerManagerPreferences preferences, @NonNull ShellCommandHelper shellCommandHelper,
+      @NonNull PowerManagerPreferences preferences, @NonNull RootChecker rootChecker,
       @NonNull TriggerInteractor triggerInteractor) {
     this.powerTriggerDB = powerTriggerDB;
     this.preferences = preferences;
-    this.shellCommandHelper = shellCommandHelper;
+    this.rootChecker = rootChecker;
     this.triggerInteractor = triggerInteractor;
   }
 
@@ -50,7 +50,7 @@ class SettingsPreferenceInteractor {
     return Observable.fromCallable(() -> {
       // If we are enabling root, check SU available
       // If we are not enabling root, then everything is ok
-      return !rootEnable || shellCommandHelper.isSUAvailable();
+      return !rootEnable || rootChecker.isSUAvailable();
     });
   }
 

--- a/powermanager-settings/src/main/java/com/pyamsoft/powermanager/settings/SettingsPreferenceModule.java
+++ b/powermanager-settings/src/main/java/com/pyamsoft/powermanager/settings/SettingsPreferenceModule.java
@@ -19,7 +19,7 @@ package com.pyamsoft.powermanager.settings;
 import android.support.annotation.NonNull;
 import com.pyamsoft.powermanager.base.PowerManagerPreferences;
 import com.pyamsoft.powermanager.base.db.PowerTriggerDB;
-import com.pyamsoft.powermanager.base.shell.ShellCommandHelper;
+import com.pyamsoft.powermanager.base.shell.RootChecker;
 import com.pyamsoft.powermanager.trigger.TriggerInteractor;
 import dagger.Module;
 import dagger.Provides;
@@ -35,9 +35,9 @@ import rx.Scheduler;
   }
 
   @Provides SettingsPreferenceInteractor provideSettingsInteractor(
-      @NonNull PowerTriggerDB powerTriggerDB, @NonNull ShellCommandHelper shellCommandHelper,
+      @NonNull PowerTriggerDB powerTriggerDB, @NonNull RootChecker rootChecker,
       @NonNull PowerManagerPreferences preferences, @NonNull TriggerInteractor triggerInteractor) {
-    return new SettingsPreferenceInteractor(powerTriggerDB, preferences, shellCommandHelper,
+    return new SettingsPreferenceInteractor(powerTriggerDB, preferences, rootChecker,
         triggerInteractor);
   }
 }


### PR DESCRIPTION
One interface will only be able to check for root status.
The other will only execute commands on SH or SU shells.

This splits up the responsibility of classes which use shell commands
in a similar way how we split up observers and modifiers